### PR TITLE
fix: decode json instead of unmarshalling

### DIFF
--- a/internal/eventhub/eventhub_unpacker.go
+++ b/internal/eventhub/eventhub_unpacker.go
@@ -3,6 +3,8 @@ package eventhub
 import (
 	"encoding/json"
 	"fmt"
+	"errors"
+	"bytes"
 
 	"github.com/jemag/aks-audit-log-go/internal/forwarder"
 	"github.com/jemag/aks-audit-log-go/internal/webhook"
@@ -21,7 +23,9 @@ func (h *HubEventUnpacker) InitConfig(f *forwarder.ForwarderConfiguration) {
 
 func (h HubEventUnpacker) Process(eventJObj []byte, mainEventName string) error {
 	var event map[string]interface{}
-	err := json.Unmarshal(eventJObj, &event)
+
+    decoder := json.NewDecoder(bytes.NewReader(eventJObj))
+	err := decoder.Decode(&event)
 	if err != nil {
 		return err
 	}

--- a/internal/eventhub/eventhub_unpacker.go
+++ b/internal/eventhub/eventhub_unpacker.go
@@ -1,9 +1,9 @@
 package eventhub
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"bytes"
 
 	"github.com/jemag/aks-audit-log-go/internal/forwarder"
 	"github.com/jemag/aks-audit-log-go/internal/webhook"
@@ -23,7 +23,7 @@ func (h *HubEventUnpacker) InitConfig(f *forwarder.ForwarderConfiguration) {
 func (h HubEventUnpacker) Process(eventJObj []byte, mainEventName string) error {
 	var event map[string]interface{}
 
-    decoder := json.NewDecoder(bytes.NewReader(eventJObj))
+	decoder := json.NewDecoder(bytes.NewReader(eventJObj))
 	err := decoder.Decode(&event)
 	if err != nil {
 		return err

--- a/internal/eventhub/eventhub_unpacker.go
+++ b/internal/eventhub/eventhub_unpacker.go
@@ -3,7 +3,6 @@ package eventhub
 import (
 	"encoding/json"
 	"fmt"
-	"errors"
 	"bytes"
 
 	"github.com/jemag/aks-audit-log-go/internal/forwarder"


### PR DESCRIPTION
Followed this solution (https://stackoverflow.com/questions/27994327/golang-json-unmarshal-unexpected-end-of-json-input):
![image](https://github.com/dfo-mpo/aks-audit-log-go/assets/140103998/437cef5f-e6c3-4334-81e8-31c915ce6340)

And now it works:
![image](https://github.com/dfo-mpo/aks-audit-log-go/assets/140103998/3ce1873e-5e07-4781-bd5e-f207916c64ca)
With prettier alerts:
![image](https://github.com/dfo-mpo/aks-audit-log-go/assets/140103998/e1e72491-cc02-4707-8786-a7fe52452455)
